### PR TITLE
README: update QuIC description, including additional links

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,7 +1,11 @@
 ![Qualcomm Innovation Center logo](https://raw.githubusercontent.com/quic-yocto/.github/main/profile/quic_logo.png)
-  
-QuIC is focused on technical innovations to mobile open-source software that leverages the unique capabilities of today's mobile devices, with a particular eye on optimizing platforms and applications which run on them via tight hardware integration.
+
+QuIC is a wholly owned subsidiary of **Qualcomm Technologies, Inc.**, focused on enabling and optimizing open-source software for use with Qualcomm ® technology.
+
+Head over to Qualcomm Technologies GitHub page to learn more about our organizations and repositories: [github.com/Qualcomm](https://github.com/qualcomm)
+
+Explore our Linux offering for IoT development based on Yocto, LTS Kernel and multi-SoCs support at our website: [qualcomm.com/developer/software/qualcomm-linux](https://www.qualcomm.com/developer/software/qualcomm-linux)
 
 ## Sound Interesting?
 
-Check out our main GitHub org at <a href="http://github.com/quic">github.com/quic</a> and visit our web site at <a href="http://quic.github.io">quic.github.io</a>. Considering a career at QuIC? Start <a href="https://www.qualcomm.com/company/careers">here</a>.
+Check out our main GitHub org at [github.com/quic](http://github.com/quic) and join our developer community at Discord: [discord.gg/qualcommdevelopernetwork](https://discord.gg/qualcommdevelopernetwork). Considering a career at QuIC? Start [here](https://www.qualcomm.com/company/careers).


### PR DESCRIPTION
Include additional links to our orgs and a dedicated line for Qualcomm Linux.

Also drop quic.github.io as that is currently invalid.

Fixes #2.